### PR TITLE
Allow longer tokens

### DIFF
--- a/SDK/Disk.Sdk/Utils/WebdavResources.Designer.cs
+++ b/SDK/Disk.Sdk/Utils/WebdavResources.Designer.cs
@@ -272,7 +272,7 @@ namespace Disk.SDK.Utils {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ([a-zA-Z0-9]){32}.
+        ///   Looks up a localized string similar to ([a-zA-Z0-9]){32,}.
         /// </summary>
         internal static string TokenRegexPattern {
             get {

--- a/SDK/Disk.Sdk/Utils/WebdavResources.resx
+++ b/SDK/Disk.Sdk/Utils/WebdavResources.resx
@@ -203,7 +203,7 @@
     <value>PUT</value>
   </data>
   <data name="TokenRegexPattern" xml:space="preserve">
-    <value>([a-zA-Z0-9]){32}</value>
+    <value>([a-zA-Z0-9]){32,}</value>
   </data>
   <data name="UnpublishBody" xml:space="preserve">
     <value>&lt;propertyupdate xmlns="DAV:"&gt;


### PR DESCRIPTION
На данный момент oauth.яндекс генерирует токены например
AQAAAAAaM3NxAAOfchDIZclockodnXgBZ9qCdD0 - длинной 39. А предыдущий
регексп обрезал токен по первые 32 символа.